### PR TITLE
Expose Write function in interface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           go-version: 1.18
       - name: Set up gotestfmt
-        uses: gotesttools/gotestfmt-action
+        uses: gotesttools/gotestfmt-action@v2
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           go-version: 1.18
       - name: Set up gotestfmt
-        uses: haveyoudebuggedit/gotestfmt-action@v2
+        uses: gotesttools/gotestfmt-action
       - uses: actions/cache@v2
         with:
           path: |

--- a/const_test.go
+++ b/const_test.go
@@ -3,7 +3,7 @@ package log_test
 import (
 	"testing"
 
-	"go.arcalot.io/log"
+	"go.arcalot.io/log/v2"
 )
 
 func TestLevelShouldPrint(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module go.arcalot.io/log
+module go.arcalot.io/log/v2
 
 go 1.18

--- a/logger.go
+++ b/logger.go
@@ -10,10 +10,16 @@ import (
 
 // Logger provides pluggable logging for Arcalot.
 type Logger interface {
+	// Debugf logs with the debug log level. This is the finest and least-consequential log type.
 	Debugf(format string, args ...interface{})
+	// Infof logs with the Info log level.
 	Infof(format string, args ...interface{})
+	// Warningf logs with the Warning log level.
 	Warningf(format string, args ...interface{})
+	// Errorf logs with the Error log level.
 	Errorf(format string, args ...interface{})
+	// Writef allows logging with convenient programmatic setting of level
+	Writef(level Level, format string, args ...interface{})
 
 	// WithLabel creates a child logger with this label attached.
 	WithLabel(name string, value string) Logger
@@ -77,22 +83,22 @@ type logger struct {
 }
 
 func (l logger) Debugf(format string, args ...interface{}) {
-	l.write(LevelDebug, format, args...)
+	l.Writef(LevelDebug, format, args...)
 }
 
 func (l logger) Infof(format string, args ...interface{}) {
-	l.write(LevelInfo, format, args...)
+	l.Writef(LevelInfo, format, args...)
 }
 
 func (l logger) Warningf(format string, args ...interface{}) {
-	l.write(LevelWarning, format, args...)
+	l.Writef(LevelWarning, format, args...)
 }
 
 func (l logger) Errorf(format string, args ...interface{}) {
-	l.write(LevelError, format, args...)
+	l.Writef(LevelError, format, args...)
 }
 
-func (l logger) write(level Level, message string, args ...interface{}) {
+func (l logger) Writef(level Level, message string, args ...interface{}) {
 	if !l.minLevel.ShouldPrint(level) {
 		return
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"go.arcalot.io/log"
+	"go.arcalot.io/log/v2"
 )
 
 //nolint:funlen

--- a/message_label_test.go
+++ b/message_label_test.go
@@ -3,7 +3,7 @@ package log_test
 import (
 	"testing"
 
-	"go.arcalot.io/log"
+	"go.arcalot.io/log/v2"
 )
 
 func TestMessageLabels(t *testing.T) {

--- a/message_test.go
+++ b/message_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"go.arcalot.io/log"
+	"go.arcalot.io/log/v2"
 )
 
 func TestMessage(t *testing.T) {

--- a/writer_golog_test.go
+++ b/writer_golog_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"go.arcalot.io/log"
+	"go.arcalot.io/log/v2"
 )
 
 func TestGoLogger(t *testing.T) {


### PR DESCRIPTION
## Changes introduced with this PR

This is useful for cases where the log level for something is set by a config option. This makes it so rather than needing to create a switch statement, which is wasteful, you can just pass in the log level.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).