### PR TITLE
upgrade golang version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.55.2
   test:
     name: go test
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,25 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          # Hard-coding version due to this bug: https://github.com/golangci/golangci-lint-action/issues/535
           version: v1.52.2
   test:
     name: go test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.6
       - name: Set up gotestfmt
         uses: gotesttools/gotestfmt-action@v2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -50,7 +49,7 @@ jobs:
           go tool cover -func /tmp/coverage.out
           echo "::endgroup::"
       - name: Upload test log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results
@@ -64,12 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.6
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.21.6
       - name: Set up gotestfmt
         uses: gotesttools/gotestfmt-action@v2
       - uses: actions/cache@v2
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.21.6
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Hard-coding version due to this bug: https://github.com/golangci/golangci-lint-action/issues/535
-          version: v1.47
+          version: v1.52.2
   test:
     name: go test
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.arcalot.io/log/v2
 
-go 1.18
+go 1.21.6

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.arcalot.io/log/v2
 
-go 1.21.6
+go 1.21

--- a/message_label_test.go
+++ b/message_label_test.go
@@ -1,22 +1,23 @@
 package log_test
 
 import (
-	"testing"
+    "testing"
 
-	"go.arcalot.io/log/v2"
+    "go.arcalot.io/log/v2"
 )
 
 func TestMessageLabels(t *testing.T) {
-	var l log.Labels = map[string]string{}
-	if l.String() != "" {
-		t.Fatalf("Incorrect label string: %s", l.String())
-	}
-	l = map[string]string{"foo": "bar"}
-	if l.String() != "foo=bar" {
-		t.Fatalf("Incorrect label string: %s", l.String())
-	}
-	l = map[string]string{"foo": "bar", "baz": "Hello world!"}
-	if l.String() != "foo=bar;baz=Hello world!" && l.String() != "baz=Hello world!;foo=bar" {
-		t.Fatalf("Incorrect label string: %s", l.String())
-	}
+    var l log.Labels = map[string]string{}
+    if l.String() != "" {
+        t.Fatalf("Incorrect label string: %s", l.String())
+    }
+    l = map[string]string{"foo": "bar"}
+    if l.String() != "foo=bar" {
+        t.Fatalf("Incorrect label string: %s", l.String())
+    }
+    l = map[string]string{"foo": "bar", "baz": "Hello world!"}
+    labelStr := l.String()
+    if labelStr != "foo=bar;baz=Hello world!" && labelStr != "baz=Hello world!;foo=bar" {
+        t.Fatalf("Incorrect label string 3: %s", l.String())
+    }
 }

--- a/message_label_test.go
+++ b/message_label_test.go
@@ -1,23 +1,23 @@
 package log_test
 
 import (
-    "testing"
+	"testing"
 
-    "go.arcalot.io/log/v2"
+	"go.arcalot.io/log/v2"
 )
 
 func TestMessageLabels(t *testing.T) {
-    var l log.Labels = map[string]string{}
-    if l.String() != "" {
-        t.Fatalf("Incorrect label string: %s", l.String())
-    }
-    l = map[string]string{"foo": "bar"}
-    if l.String() != "foo=bar" {
-        t.Fatalf("Incorrect label string: %s", l.String())
-    }
-    l = map[string]string{"foo": "bar", "baz": "Hello world!"}
-    labelStr := l.String()
-    if labelStr != "foo=bar;baz=Hello world!" && labelStr != "baz=Hello world!;foo=bar" {
-        t.Fatalf("Incorrect label string 3: %s", l.String())
-    }
+	var l log.Labels = map[string]string{}
+	if l.String() != "" {
+		t.Fatalf("Incorrect label string: %s", l.String())
+	}
+	l = map[string]string{"foo": "bar"}
+	if l.String() != "foo=bar" {
+		t.Fatalf("Incorrect label string: %s", l.String())
+	}
+	l = map[string]string{"foo": "bar", "baz": "Hello world!"}
+	labelStr := l.String()
+	if labelStr != "foo=bar;baz=Hello world!" && labelStr != "baz=Hello world!;foo=bar" {
+		t.Fatalf("Incorrect label string 3: %s", l.String())
+	}
 }

--- a/message_label_test.go
+++ b/message_label_test.go
@@ -8,16 +8,18 @@ import (
 
 func TestMessageLabels(t *testing.T) {
 	var l log.Labels = map[string]string{}
+	labelStrEmpty := l.String()
 	if l.String() != "" {
-		t.Fatalf("Incorrect label string: %s", l.String())
+		t.Fatalf("Incorrect label string: %s", labelStrEmpty)
 	}
 	l = map[string]string{"foo": "bar"}
-	if l.String() != "foo=bar" {
-		t.Fatalf("Incorrect label string: %s", l.String())
+	labelStr1Key := l.String()
+	if labelStr1Key != "foo=bar" {
+		t.Fatalf("Incorrect label string: %s", labelStr1Key)
 	}
 	l = map[string]string{"foo": "bar", "baz": "Hello world!"}
-	labelStr := l.String()
-	if labelStr != "foo=bar;baz=Hello world!" && labelStr != "baz=Hello world!;foo=bar" {
-		t.Fatalf("Incorrect label string 3: %s", l.String())
+	labelStr2Keys := l.String()
+	if labelStr2Keys != "foo=bar;baz=Hello world!" && labelStr2Keys != "baz=Hello world!;foo=bar" {
+		t.Fatalf("Incorrect label string 3: %s", labelStr2Keys)
 	}
 }


### PR DESCRIPTION
## Changes introduced with this PR

- [X] Upgrade module and ci to use golang 1.21.6.
- [X] Upgrade `golangci-lint` to 1.52.2.
- [X] Upgrade ci actions.
- [X] Bug fix for `TestMessageLabels`.
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).