### PR TITLE
pin golang ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Pin Golang version for linting
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.6        
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
## Changes introduced with this PR

Pin jobs `golangci-lint` and `test` to same golang version.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).