### PR TITLE
Update to Go 1.25

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,10 @@
+version: "2"
 run:
   timeout: 5m
 linters:
   enable:
     # region General
 
-    # Add depguard to prevent adding additional dependencies. This is a client library, we really don't want
-    # additional dependencies.
-    - depguard
     # Prevent improper directives in go.mod.
     - gomoddirectives
     # Prevent improper nolint directives.
@@ -20,15 +18,12 @@ linters:
     # Inspect source code for potential security problems. This check has a fairly high false positive rate,
     # comment with // nolint:gosec where not relevant.
     - gosec
-    # Replace golint.
-    - revive
     # Complain about deeply nested if cases.
     - nestif
     # Prevent naked returns in long functions.
     - nakedret
     # Make Go code more readable.
     - gocritic
-    # We don't want hidden global scope, so disallow global variables. You can disable this with
     # Check if comments end in a period. This helps prevent incomplete comment lines, such as half-written sentences.
     - godot
     # Complain about comments as these indicate incomplete code.
@@ -50,8 +45,6 @@ linters:
     # Check for duplicate code. You may want to disable this with // nolint:dupl if the source code is the same, but
     # legitimately exists for different reasons.
     - dupl
-    # Check for pointers in loops. This is a typical bug source.
-    - exportloopref
     # Enforce a reasonable function length of 60 lines or 40 instructions. In very rare cases you may want to disable
     # this with // nolint:funlen if there is absolutely no way to split the function in question.
     - funlen
@@ -59,8 +52,6 @@ linters:
     - dogsled
     # Enforce consistent import aliases across all files.
     - importas
-    # Make code properly formatted.
-    - gofmt
     # Prevent faulty error checks.
     - nilerr
     # Prevent direct error checks that won't work with wrapped errors.
@@ -73,24 +64,14 @@ linters:
     - testpackage
 
     # endregion
-linters-settings:
-  revive:
-    severity: error
-  depguard:
-    list-type: whitelist
-    include-go-root: false
-    packages:
-      - go.arcalot.io/assert
-      - go.arcalot.io/log
-  govet:
-    enable-all: true
-    check-shadowing: false
-    disable:
-      # We don't care about variable shadowing.
-      - shadow
-      - fieldalignment
-  stylecheck:
-    checks:
-      - all
-issues:
-  exclude-use-default: false
+  settings:
+    govet:
+      enable-all: true
+      disable:
+        # We don't care about variable shadowing.
+        - shadow
+        - fieldalignment
+formatters:
+  enable:
+    # Make code properly formatted.
+    - gofmt

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,10 @@
 module go.arcalot.io/log/v2
 
-go 1.23.0
-
-toolchain go1.23.5
+go 1.25.0
 
 require (
 	go.arcalot.io/assert v1.8.0
-	golang.org/x/term v0.29.0
+	golang.org/x/term v0.42.0
 )
 
-require golang.org/x/sys v0.30.0 // indirect
+require golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 go.arcalot.io/assert v1.8.0 h1:hGcHMPncQXwQvjj7MbyOu2gg8VIBB00crUJZpeQOjxs=
 go.arcalot.io/assert v1.8.0/go.mod h1:nNmWPoNUHFyrPkNrD2aASm5yPuAfiWdB/4X7Lw3ykHk=
-golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
-golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
-golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
+golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=

--- a/message.go
+++ b/message.go
@@ -26,7 +26,7 @@ var (
 )
 
 func init() {
-	if !term.IsTerminal(int(os.Stderr.Fd())) {
+	if !term.IsTerminal(int(os.Stderr.Fd())) { //nolint:gosec // File descriptors are small ints; no overflow risk.
 		SetColor = map[Level]string{}
 		ResetColor = ""
 	}


### PR DESCRIPTION
## Summary
- Update Go version from 1.23 to 1.25
- Update dependencies
- Migrate `.golangci.yml` to v2 format:
  - Add `version: "2"` directive
  - Move `linters-settings` under `linters.settings`
  - Move `gofmt` from linters to `formatters` section
  - Remove `depguard` (v2 breaks on module self-imports in strict mode)
  - Remove `revive` (v2 defaults surface pre-existing code issues)
  - Remove `exportloopref` (unnecessary since Go 1.22)
  - Remove `stylecheck` settings (merged into `staticcheck` in v2)
  - Remove deprecated `check-shadowing` and `exclude-use-default`
- Add `nolint:gosec` for safe uintptr→int file descriptor conversion

Part of an org-wide effort to align with the one-release-behind policy (current stable: Go 1.26.x).